### PR TITLE
Enable dummy data generation via DataDownloader

### DIFF
--- a/DataGeneration.py
+++ b/DataGeneration.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import pandas as pd
 import numpy as np
@@ -15,25 +14,83 @@ class DataGeneration:
         Sanitized = FileName.replace(":", "-")
         return self.CacheDir / Sanitized
 
-    def DataDownloader(self, TickerSymbol, StartDate, EndDate, Interval="1d"):
-        CachePath = self._GetCachePath(TickerSymbol, StartDate, EndDate, Interval)
+    def DataDownloader(
+        self,
+        TickerSymbol,
+        StartDate,
+        EndDate,
+        Interval="1d",
+        UseDummyData=False,
+    ):
+        CachePath = self._GetCachePath(
+            TickerSymbol,
+            StartDate,
+            EndDate,
+            Interval,
+        )
+        if UseDummyData:
+            Days = (
+                pd.to_datetime(EndDate) - pd.to_datetime(StartDate)
+            ).days
+            Data = self._GenerateDummyData(Days=Days)
+            Data.to_csv(CachePath)
+            return Data
         if CachePath.exists():
             Data = pd.read_csv(CachePath, index_col=0, parse_dates=True)
             return Data
-        Data = yf.download(TickerSymbol, start=StartDate, end=EndDate, interval=Interval)
+        Data = yf.download(
+            TickerSymbol,
+            start=StartDate,
+            end=EndDate,
+            interval=Interval,
+        )
         if not Data.empty:
             Data.to_csv(CachePath)
         return Data
 
     def SaveCache(self, Data, TickerSymbol, StartDate, EndDate, Interval="1d"):
-        CachePath = self._GetCachePath(TickerSymbol, StartDate, EndDate, Interval)
+        CachePath = self._GetCachePath(
+            TickerSymbol,
+            StartDate,
+            EndDate,
+            Interval,
+        )
         Data.to_csv(CachePath)
 
-    def GenerateDummyData(self, StartPrice=100, Mu=0.001, Sigma=0.01, Days=252):
+    def _GenerateDummyData(
+        self,
+        StartPrice=100,
+        Mu=0.001,
+        Sigma=0.01,
+        Days=252,
+    ):
         Dt = 1.0 / Days
-        Returns = np.random.normal(loc=Mu * Dt, scale=Sigma * np.sqrt(Dt), size=Days)
+        Returns = np.random.normal(
+            loc=Mu * Dt,
+            scale=Sigma * np.sqrt(Dt),
+            size=Days,
+        )
         Price = [StartPrice]
         for R in Returns:
             Price.append(Price[-1] * np.exp(R))
-        Index = pd.date_range(start=pd.Timestamp.today(), periods=Days + 1, freq="D")
-        return pd.DataFrame({"Close": Price}, index=Index)
+        Index = pd.date_range(
+            start=pd.Timestamp.today(),
+            periods=Days,
+            freq="D",
+        )
+        Data = pd.DataFrame(index=Index)
+        Data["Open"] = Price[:-1]
+        PriceArray = np.array(Price[1:])
+        OpenArray = np.array(Price[:-1])
+        HighMultiplier = np.random.uniform(1.0, 1.02, size=Days)
+        LowMultiplier = np.random.uniform(0.98, 1.0, size=Days)
+        Data["High"] = (
+            np.maximum(OpenArray, PriceArray) * HighMultiplier
+        )
+        Data["Low"] = (
+            np.minimum(OpenArray, PriceArray) * LowMultiplier
+        )
+        Data["Close"] = PriceArray
+        Data["Adj Close"] = PriceArray
+        Data["Volume"] = np.random.randint(100000, 1000000, size=Days)
+        return Data

--- a/UnitTests/DataGenerationTests.py
+++ b/UnitTests/DataGenerationTests.py
@@ -15,16 +15,35 @@ class DataGenerationTests(TestCase):
         self.TempDir.cleanup()
 
     def test_DataDownloader_uses_cache(self):
-        SampleData = pd.DataFrame({"Close": [1, 2, 3]}, index=pd.date_range("2020-01-01", periods=3))
-        with patch("DataGeneration.yf.download", return_value=SampleData) as MockDownload:
-            Data = self.Generator.DataDownloader("TEST", "2020-01-01", "2020-01-03", "1d")
+        SampleData = pd.DataFrame(
+            {"Close": [1, 2, 3]}, index=pd.date_range("2020-01-01", periods=3)
+        )
+        with patch(
+            "DataGeneration.yf.download",
+            return_value=SampleData,
+        ) as MockDownload:
+            self.Generator.DataDownloader(
+                "TEST", "2020-01-01", "2020-01-03", "1d"
+            )
             self.assertTrue(MockDownload.called)
         with patch("DataGeneration.yf.download") as MockDownload:
-            Data2 = self.Generator.DataDownloader("TEST", "2020-01-01", "2020-01-03", "1d")
+            Data2 = self.Generator.DataDownloader(
+                "TEST", "2020-01-01", "2020-01-03", "1d"
+            )
             self.assertFalse(MockDownload.called)
         pd.testing.assert_frame_equal(Data2, SampleData, check_freq=False)
 
-    def test_GenerateDummyData_length(self):
-        Data = self.Generator.GenerateDummyData(StartPrice=10, Days=10)
-        self.assertEqual(len(Data), 11)
-        self.assertEqual(Data.iloc[0]["Close"], 10)
+    def test_DataDownloader_generates_dummy_data(self):
+        Data = self.Generator.DataDownloader(
+            "TEST",
+            "2020-01-01",
+            "2020-01-10",
+            "1d",
+            UseDummyData=True,
+        )
+        ExpectedLength = (
+            pd.to_datetime("2020-01-10") - pd.to_datetime("2020-01-01")
+        ).days
+        self.assertEqual(len(Data), ExpectedLength)
+        self.assertIn("Open", Data.columns)
+        self.assertIn("Close", Data.columns)

--- a/main.py
+++ b/main.py
@@ -5,7 +5,13 @@ def main():
     Generator = DataGeneration()
     Data = Generator.DataDownloader("AAPL", "2022-01-01", "2022-01-10", "1d")
     print(Data.head())
-    Dummy = Generator.GenerateDummyData()
+    Dummy = Generator.DataDownloader(
+        "DUMMY",
+        "2022-01-01",
+        "2022-01-10",
+        "1d",
+        UseDummyData=True,
+    )
     print(Dummy.head())
 
 


### PR DESCRIPTION
## Summary
- update `DataGeneration` to optionally create dummy data within `DataDownloader`
- add an internal dummy data generator producing realistic columns
- adjust main script to use dummy data option
- refactor unit tests for new interface
- ensure code meets lint guidelines